### PR TITLE
Fixes #20

### DIFF
--- a/src/config-helpers.ts
+++ b/src/config-helpers.ts
@@ -44,7 +44,7 @@ export function getSafePackageName(name: string): string | undefined {
   return name.replace(/[^\w-]/g, '-').replace(/^-+/, '');
 }
 
-export function createNGCConfig(filePath: string, moduleId: string, configs?: TSConfigs): void {
+export function createNGCConfig(filePath: string, moduleId: string, configs?: TSConfigs, flatModuleId?:string): void {
   const result = mergeInto(<TSConfigs>{
     compilerOptions: {
       outDir: './ngc-compiled',
@@ -68,7 +68,7 @@ export function createNGCConfig(filePath: string, moduleId: string, configs?: TS
     result.angularCompilerOptions!.skipTemplateCodegen = true;
   }
   if (isNil(result.angularCompilerOptions!.flatModuleId)) {
-    result.angularCompilerOptions!.flatModuleId = moduleId;
+    result.angularCompilerOptions!.flatModuleId = flatModuleId || moduleId;
   }
   if (!isNil(result.include)) {
     delete result.include;

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,7 @@ export async function main(projectPath: string, configFilePath?: string, buildOp
   // AngularCompiler configurations
   const ngcBuildDir = path.resolve(buildDir, 'ngc-compiled');
   const ngcConfigPath = path.resolve(buildDir, 'tsconfig-ngc.json');
-  createNGCConfig(ngcConfigPath, moduleId, configs);
+  createNGCConfig(ngcConfigPath, moduleId, configs, packageName);
 
   // Compile with NGC
   await ngcCompiler(ngcConfigPath, { basePath: buildDir });

--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -28,6 +28,39 @@ describe('ConfigHelpers', () => {
     assert.property(defaultTSConfig, 'compilerOptions');
 
     const moduleId = 'check-mod';
+    const flatModuleId = '@scope/module';
+    createNGCConfig(ngcConfigsPath, moduleId, defaultTSConfig, flatModuleId);
+
+    ({ configs: defaultTSConfig, error  } = parseConfigFile(ngcConfigsPath));
+
+    assert.isDefined(defaultTSConfig, 'files');
+    assert.isArray(defaultTSConfig.files);
+    assert.deepEqual(defaultTSConfig.files, ['./src/public_api.ts']);
+
+    assert.isUndefined(error);
+    assert.property(defaultTSConfig, 'compilerOptions');
+    assert.propertyVal(defaultTSConfig.compilerOptions, 'outDir', './ngc-compiled');
+    assert.propertyVal(defaultTSConfig.compilerOptions, 'module', 'es2015');
+
+    assert.property(defaultTSConfig, 'angularCompilerOptions');
+    assert.propertyVal(defaultTSConfig.angularCompilerOptions, 'flatModuleId', flatModuleId);
+    assert.propertyVal(defaultTSConfig.angularCompilerOptions, 'annotateForClosureCompiler', false);
+  });
+
+
+  it('createNGCConfig: no flatModuleId', () => {
+
+    const ngcConfigsPath = path.resolve(__dirname, 'tsconfig.ngc.json');
+
+    let { configs: defaultTSConfig, error } = parseConfigFile(defaultTSConfigPath);
+    defaultTSConfig.angularCompilerOptions = {
+      annotateForClosureCompiler: false,
+    };
+
+    assert.isUndefined(error);
+    assert.property(defaultTSConfig, 'compilerOptions');
+
+    const moduleId = 'check-mod';
     createNGCConfig(ngcConfigsPath, moduleId, defaultTSConfig);
 
     ({ configs: defaultTSConfig, error  } = parseConfigFile(ngcConfigsPath));


### PR DESCRIPTION
Now the flatModuleID will be same as package-name by default.

I have added an optional varible in config-helper's createNGC config to pass flatModuleId from main.ts